### PR TITLE
Removed JPackage repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,20 +11,20 @@ spacewalk_repo:
     gpgkey: "{{ spacewalk_gpg_key }}"
     proxy: "_none_"
 
-  - repoid: jpackage-generic
-    description: "JPackage generic"
-    file: jpackage-generic
-    baseurl: "{{ spacewalk_jpackage_url }}"
+  - repoid: spacewalkproject-java-packages
+    description: "Spacewalk Java packages"
+    file: spacewalkproject-java-packages
+    baseurl: "{{ spacewalk_java_repo_url }}"
     enabled: true
     gpgcheck: true
-    gpgkey: "{{ spacewalk_jpackage_gpg_key }}"
+    gpgkey: "{{ spacewalk_java_repo_gpg_key }}"
     proxy: "_none_"
 
 #spacewalk_version: "2.7"
 spacewalk_repo_url: "http://yum.spacewalkproject.org/{{ spacewalk_version | default('latest') }}/RHEL/{{ ansible_distribution_major_version }}/$basearch/"
 spacewalk_gpg_key: "http://yum.spacewalkproject.org/RPM-GPG-KEY-spacewalk-2015"
-spacewalk_jpackage_url: "http://mirrors.dotsrc.org/pub/jpackage/5.0/generic/free/"
-spacewalk_jpackage_gpg_key: "http://www.jpackage.org/jpackage.asc"
+spacewalk_java_repo_url: "https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/java-packages/epel-7-$basearch/"
+spacewalk_java_repo_gpg_key: "https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/java-packages/pubkey.gpg"
 
 spacewalk_pkgs:
   - spacewalk-setup-postgresql

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,7 +9,7 @@
   command: "subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-optional-rpms"
   when: ansible_distribution == "RedHat"
 
-- name: Add spacewalk and jpackage repository
+- name: Add spacewalk and Java packages repository
   yum_repository:
     name: "{{ item.repoid }}"
     description: "{{ item.description }}"
@@ -26,7 +26,7 @@
     key: "{{ item }}"
   with_items:
     - "{{ spacewalk_gpg_key }}"
-    - "{{ spacewalk_jpackage_gpg_key }}"
+    - "{{ spacewalk_java_repo_gpg_key }}"
 
 - name: Install spacewalk packages
   yum:


### PR DESCRIPTION
As per the latest [install guide](https://github.com/spacewalkproject/spacewalk/wiki/HowToInstall) from the Spacewalk Wiki, remove the JPackage repo and add the [Spacewalk Java packages](https://github.com/spacewalkproject/spacewalk/wiki/HowToInstall#java-packages-7-use-for-red-hat-enterprise-linux-7-scientific-linux-7-centos-7) repo.

Tested on CentOS 7.4