### PR TITLE
Fix idempotency + add some useful extra packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,11 @@ spacewalk_pkgs:
   - spacewalk-setup-postgresql
   - spacewalk-postgresql
 
+spacewalk_extra_pkgs:
+  - spacewalk-utils
+  - spacewalk-reports
+  - spacecmd
+
 spacewalk_firewall:
   services:
     - "http"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,3 +34,11 @@
     state: present
   with_items:
     - "{{ spacewalk_pkgs }}"
+
+- name: Install spacewalk extra packages
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "{{ spacewalk_extra_pkgs }}"
+  when: spacewalk_extra_pkgs is defined

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -5,5 +5,11 @@
     src: spacewalk-answer-file.j2
     dest: /root/spacewalk-answer-file
 
+- name: Check the presence of rhn.conf file
+  stat:
+    path: /etc/rhn/rhn.conf
+  register: rhnconf
+
 - name: Install spacewalk
   command: spacewalk-setup --answer-file=/root/spacewalk-answer-file
+  when: not rhnconf.stat.exists


### PR DESCRIPTION
Hi @ichundu 
This PR will fix idempotency issue with the role when it will be applied again to an existing spacewalk host.
`spacewalk-setup` will not run again if `rhn.conf` file is present

Moreover, I've added a new variable `spacewalk_extra_pkgs` with a list of useful packages to be installed by default (spacecmd, spacewalk-reports and spacewalk-utils)