### PR TITLE
Initialise the database before running spacewalk-setup (workaround for bz #1524221) + custom selinux policy workaround for bz #1522939)

### DIFF
--- a/files/reposync_tomcat.te
+++ b/files/reposync_tomcat.te
@@ -1,0 +1,7 @@
+module reposync_tomcat 1.0;
+
+require {
+        type tomcat_t;
+        type spacewalk_log_t;
+        class file read;
+}

--- a/files/reposync_tomcat.te
+++ b/files/reposync_tomcat.te
@@ -3,7 +3,7 @@ module reposync_tomcat 1.0;
 require {
 	type tomcat_t;
 	type spacewalk_log_t;
-	class file read;
+	class file { open read };
 }
 
 #============= tomcat_t ==============

--- a/files/reposync_tomcat.te
+++ b/files/reposync_tomcat.te
@@ -1,7 +1,10 @@
 module reposync_tomcat 1.0;
 
 require {
-        type tomcat_t;
-        type spacewalk_log_t;
-        class file read;
+	type tomcat_t;
+	type spacewalk_log_t;
+	class file read;
 }
+
+#============= tomcat_t ==============
+allow tomcat_t spacewalk_log_t:file read;

--- a/files/reposync_tomcat.te
+++ b/files/reposync_tomcat.te
@@ -7,4 +7,4 @@ require {
 }
 
 #============= tomcat_t ==============
-allow tomcat_t spacewalk_log_t:file read;
+allow tomcat_t spacewalk_log_t:file { open read };

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -66,8 +66,9 @@
 
     - name: Remove SELinux policy temporary files
       file:
-        path: /tmp/reposync_tomcat.*
+        path: "{{ item }}"
         state: absent
+      with_fileglob: /tmp/reposync_tomcat.*
       tags: selinux
 
   when: ansible_selinux and ansible_selinux.status == "enabled"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -31,3 +31,43 @@
     dest: /etc/hosts
     line: "{{ ansible_default_ipv4.address }} {{ ansible_fqdn }} {{ ansible_hostname }}"
     state: present
+
+- name: Create a custom reposync_tomcat policy for SELinux (bugzilla #1522939)
+  block:
+
+    - name: Get the loaded SELinux modules
+      command: semodule -l
+      register: semodule
+      changed_when: False
+      tags: selinux
+      check_mode: no
+
+    - name: Copy the reposync_tomcat SELinux policy file
+      copy:
+        src: reposync_tomcat.te
+        dest: /tmp/reposync_tomcat.te
+      when: semodule.stdout.find('reposync_tomcat') == -1
+      tags: selinux
+
+    - name: Compile the SELinux module file
+      command: checkmodule -M -m -o /tmp/reposync_tomcat.mod /tmp/reposync_tomcat.te
+      when: semodule.stdout.find('reposync_tomcat') == -1
+      tags: selinux
+
+    - name: Build SELinux policy package
+      command: semodule_package -o /tmp/reposync_tomcat.pp -m /tmp/reposync_tomcat.mod
+      when: semodule.stdout.find('reposync_tomcat') == -1
+      tags: selinux
+
+    - name: Load the reposync_tomcat SELinux policy
+      command: semodule -i /tmp/reposync_tomcat.pp
+      when: semodule.stdout.find('reposync_tomcat') == -1
+      tags: selinux
+
+    - name: Remove SELinux policy temporary files
+      file:
+        path: /tmp/reposync_tomcat.*
+        state: absent
+      tags: selinux
+
+  when: ansible_selinux and ansible_selinux.status == "enabled"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -68,7 +68,10 @@
       file:
         path: "{{ item }}"
         state: absent
-      with_fileglob: /tmp/reposync_tomcat.*
+      with_items:
+        - "/tmp/reposync_tomcat.mod"
+        - "/tmp/reposync_tomcat.pp"
+        - "/tmp/reposync_tomcat.te"
       tags: selinux
 
   when: ansible_selinux and ansible_selinux.status == "enabled"

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -14,8 +14,9 @@
   command: postgresql-setup initdb
   environment:
     LANG: en_US.utf8
+  args:
+    creates: /var/lib/pgsql/data
   when: not rhnconf.stat.exists
-  creates: /var/lib/pgsql/data
 
 - name: Install spacewalk
   command: spacewalk-setup --answer-file=/root/spacewalk-answer-file

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -10,6 +10,13 @@
     path: /etc/rhn/rhn.conf
   register: rhnconf
 
+- name: Initialise the database before running spacewalk-setup (bugzilla #1524221)
+  command: postgresql-setup initdb
+  environment:
+    LANG: en_US.utf8
+  when: not rhnconf.stat.exists
+  creates: /var/lib/pgsql/data
+
 - name: Install spacewalk
   command: spacewalk-setup --answer-file=/root/spacewalk-answer-file
   when: not rhnconf.stat.exists


### PR DESCRIPTION
Without this fix, the **spacewalk-setup** will fail.
Please, refer to: https://bugzilla.redhat.com/show_bug.cgi?id=1524221

Moreover, the role will create a custom SELinux policy in order to fix "**Reposync: Internal Server Error**" issue.
Please, refer to: https://cstan.io/?p=11264&lang=en
and https://bugzilla.redhat.com/show_bug.cgi?id=1522939

P.s.: this is specific for spacewalk 2.7 and 2.8-nightly. I can put a conditional with a version check if you prefer 